### PR TITLE
Add __repr__ methods and simplify display helpers

### DIFF
--- a/Administrador.py
+++ b/Administrador.py
@@ -29,3 +29,7 @@ class Administrador:
     
     def set_contrasena(self, contrasena: str):
         self._contrasena = contrasena
+
+    def __repr__(self) -> str:
+        return (f"Administrador(ID={self._id}, Nombre='{self._nombre}', "
+                f"Email='{self._email}')")

--- a/Administradores.py
+++ b/Administradores.py
@@ -7,4 +7,4 @@ class Administradores(UsuariosGen[Administrador]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Administrador) -> str:
-        return f"ID: {elemento.get_id()}, Nombre: {elemento.get_nombre()}, Email: {elemento.get_email()}"
+        return str(elemento)

--- a/Carrito.py
+++ b/Carrito.py
@@ -51,3 +51,9 @@ class Carrito:
     
     def set_precioFinal(self, precioFinal: float):
         self._precioFinal = precioFinal
+
+    def __repr__(self) -> str:
+        return (
+            f"Carrito(ID={self._id}, Productos={self._productoTotal}, "
+            f"PrecioTotal={self._precioTotal}€, Estado='{self._estado}')"
+        )

--- a/Carritos.py
+++ b/Carritos.py
@@ -8,7 +8,7 @@ class Carritos(PedidosGen[Carrito]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Carrito) -> str:
-        return f"ID: {elemento.get_id()}, Productos: {elemento.get_productoTotal()}, Precio Total: {elemento.get_precioTotal()}€, Estado: {elemento.get_estado()}"
+        return str(elemento)
     
     def agruparPorDescuentoTotal(self, descuento: float) -> List[Carrito]:
         return [elemento for elemento in self._elementos 

--- a/Cliente.py
+++ b/Cliente.py
@@ -87,3 +87,9 @@ class Cliente:
     
     def set_historial(self, historial: str):
         self._historial = historial
+
+    def __repr__(self) -> str:
+        return (
+            f"Cliente(ID={self._id}, Nombre='{self._nombre}', Email='{self._email}', "
+            f"Categoria='{self._categoria}')"
+        )

--- a/Clientes.py
+++ b/Clientes.py
@@ -8,7 +8,7 @@ class Clientes(UsuariosGen[Cliente]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Cliente) -> str:
-        return f"ID: {elemento.get_id()}, Nombre: {elemento.get_nombre()}, Email: {elemento.get_email()}, Categoria: {elemento.get_categoria()}"
+        return str(elemento)
     
     def agruparPorCategoria(self, categoria: str) -> List[Cliente]:
         return [elemento for elemento in self._elementos 

--- a/Electrodomestico.py
+++ b/Electrodomestico.py
@@ -43,3 +43,9 @@ class Electrodomestico:
     
     def set_etiquetaDeConsumo(self, etiquetaDeConsumo: str):
         self._etiquetaDeConsumo = etiquetaDeConsumo
+
+    def __repr__(self) -> str:
+        return (
+            f"Electrodomestico(ID={self._id}, Tipo='{self._tipo}', Marca='{self._marca}', "
+            f"Precio={self._precio}€, Etiqueta='{self._etiquetaDeConsumo}')"
+        )

--- a/Electrodomesticos.py
+++ b/Electrodomesticos.py
@@ -8,7 +8,7 @@ class Electrodomesticos(ProductosGen[Electrodomestico]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Electrodomestico) -> str:
-        return f"ID: {elemento.get_id()}, Tipo: {elemento.get_tipo()}, Marca: {elemento.get_marca()}, Precio: {elemento.get_precio()}€, Etiqueta: {elemento.get_etiquetaDeConsumo()}"
+        return str(elemento)
     
     def agruparPorEtiquetaConsumo(self, etiquetaConsumo: str) -> List[Electrodomestico]:
         return [elemento for elemento in self._elementos 

--- a/Envio.py
+++ b/Envio.py
@@ -58,3 +58,9 @@ class Envio:
     
     def set_volumen(self, volumen: float):
         self._volumen = volumen
+
+    def __repr__(self) -> str:
+        return (
+            f"Envio(ID={self._id}, Pedido='{self._pedido}', Estado='{self._estado}', "
+            f"Transportista='{self._transportista}')"
+        )

--- a/Envios.py
+++ b/Envios.py
@@ -8,7 +8,7 @@ class Envios(PedidosGen[Envio]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Envio) -> str:
-        return f"ID: {elemento.get_id()}, Pedido: {elemento.get_pedido()}, Estado: {elemento.get_estado()}, Transportista: {elemento.get_transportista()}"
+        return str(elemento)
     
     def agruparPorTransportista(self, transportista: str) -> List[Envio]:
         return [elemento for elemento in self._elementos 

--- a/EquipoSonido.py
+++ b/EquipoSonido.py
@@ -43,3 +43,9 @@ class EquipoSonido:
     
     def set_potencia(self, potencia: int):
         self._potencia = potencia
+
+    def __repr__(self) -> str:
+        return (
+            f"EquipoSonido(ID={self._id}, Tipo='{self._tipo}', Marca='{self._marca}', "
+            f"Precio={self._precio}€, Potencia={self._potencia}W)"
+        )

--- a/EquiposSonido.py
+++ b/EquiposSonido.py
@@ -8,7 +8,7 @@ class EquiposSonido(ProductosGen[EquipoSonido]):
         super().__init__()
     
     def mostrarElemento(self, elemento: EquipoSonido) -> str:
-        return f"ID: {elemento.get_id()}, Tipo: {elemento.get_tipo()}, Marca: {elemento.get_marca()}, Precio: {elemento.get_precio()}€, Potencia: {elemento.get_potencia()}W"
+        return str(elemento)
     
     def agruparPorPotencia(self, potencia: int) -> List[EquipoSonido]:
         return [elemento for elemento in self._elementos 

--- a/Ordenador.py
+++ b/Ordenador.py
@@ -57,3 +57,9 @@ class Ordenador:
     
     def set_memoriaRam(self, memoriaRam: int):
         self._memoriaRam = memoriaRam
+
+    def __repr__(self) -> str:
+        return (
+            f"Ordenador(ID={self._id}, Tipo='{self._tipo}', Marca='{self._marca}', "
+            f"Precio={self._precio}€, Procesador='{self._procesador}', RAM={self._memoriaRam}GB)"
+        )

--- a/Ordenadores.py
+++ b/Ordenadores.py
@@ -8,7 +8,7 @@ class Ordenadores(ProductosGen[Ordenador]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Ordenador) -> str:
-        return f"ID: {elemento.get_id()}, Tipo: {elemento.get_tipo()}, Marca: {elemento.get_marca()}, Precio: {elemento.get_precio()}€, Procesador: {elemento.get_procesador()}, RAM: {elemento.get_memoriaRam()}GB"
+        return str(elemento)
     
     def agruparPorProcesador(self, procesador: str) -> List[Ordenador]:
         return [elemento for elemento in self._elementos 

--- a/Telefono.py
+++ b/Telefono.py
@@ -50,3 +50,9 @@ class Telefono:
     
     def set_sistemaOperativo(self, sistemaOperativo: str):
         self._sistemaOperativo = sistemaOperativo
+
+    def __repr__(self) -> str:
+        return (
+            f"Telefono(ID={self._id}, Tipo='{self._tipo}', Marca='{self._marca}', "
+            f"Precio={self._precio}€, Pulgadas={self._pulgadas}\", SO='{self._sistemaOperativo}')"
+        )

--- a/Telefonos.py
+++ b/Telefonos.py
@@ -8,7 +8,7 @@ class Telefonos(ProductosGen[Telefono]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Telefono) -> str:
-        return f"ID: {elemento.get_id()}, Tipo: {elemento.get_tipo()}, Marca: {elemento.get_marca()}, Precio: {elemento.get_precio()}€, Pulgadas: {elemento.get_pulgadas()}\", SO: {elemento.get_sistemaOperativo()}"
+        return str(elemento)
     
     def agruparPorSistemaOperativo(self, sistemaOperativo: str) -> List[Telefono]:
         return [elemento for elemento in self._elementos 

--- a/Television.py
+++ b/Television.py
@@ -50,3 +50,9 @@ class Television:
     
     def set_pulgadas(self, pulgadas: float):
         self._pulgadas = pulgadas
+
+    def __repr__(self) -> str:
+        return (
+            f"Television(ID={self._id}, Tipo='{self._tipo}', Marca='{self._marca}', "
+            f"Precio={self._precio}€, Pulgadas={self._pulgadas}\", Conectividad='{self._conectividad}')"
+        )

--- a/Televisiones.py
+++ b/Televisiones.py
@@ -8,7 +8,7 @@ class Televisiones(ProductosGen[Television]):
         super().__init__()
     
     def mostrarElemento(self, elemento: Television) -> str:
-        return f"ID: {elemento.get_id()}, Tipo: {elemento.get_tipo()}, Marca: {elemento.get_marca()}, Precio: {elemento.get_precio()}€, Pulgadas: {elemento.get_pulgadas()}\", Conectividad: {elemento.get_conectividad()}"
+        return str(elemento)
     
     def agruparPorConectividad(self, conectividad: str) -> List[Television]:
         return [elemento for elemento in self._elementos 


### PR DESCRIPTION
## Summary
- implement `__repr__` methods for all entity classes so printing them shows useful details
- adjust `mostrarElemento` methods in collection classes to use the new representations

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68421b3847948331aeac81ae76304e50